### PR TITLE
Release 2.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,10 @@ Changelog
 
 [Unreleased]
 ------------
--
+### Added
+- Quiz Queue
+  - Button for hosts to add the quiz they are on to the queue.
+  - Draggable (for hosts) list of quizzes in the queue.
 
 [v2.2.0] - 2021-08-16
 ---------------------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ Changelog
   - Go to quiz button for hosts to visit the page of quizzes in the queue.
   - Controls for hosts to toggle and customise interval for auto changing to
     next quiz.
+    - Countdown under leaderboard displaying time left until change to next
+    quiz.
+    - Button to cancel the countdown for hosts.
 
 [v2.2.0] - 2021-08-16
 ---------------------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,9 +16,11 @@ Changelog
   - Go to quiz button for hosts to visit the page of quizzes in the queue.
   - Controls for hosts to toggle and customise interval for auto changing to
     next quiz.
+	- Option to set default interval for auto chaning.
     - Countdown under leaderboard displaying time left until change to next
     quiz.
     - Button to cancel the countdown for hosts.
+- Option to set default duration for next quiz polls.
 
 [v2.2.0] - 2021-08-16
 ---------------------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@ Changelog
 
 [Unreleased]
 ------------
+-
+
+[v2.3.0] - 2021-08-16
+---------------------
+[GitHub Release Page](https://github.com/ToranSharma/Xporcle-Extension/releases/tag/v2.3.0)
 ### Added
 - Quiz Queue
   - Button for hosts to add the quiz they are on to the queue.
@@ -24,7 +29,6 @@ Changelog
 
 ### Changed
 - Xporcle interface now scrollable if longer than available space.
-
 
 [v2.1.0] - 2021-08-14
 ---------------------
@@ -159,6 +163,7 @@ Changelog
 - Options page popup placeholder.
 
 [Unreleased]: https://github.com/ToranSharma/Xporcle-Extension/compare/master...develop
+[v2.3.0]: https://github.com/ToranSharma/Xporcle-Extension/compare/v2.2.0...v2.3.0
 [v2.2.0]: https://github.com/ToranSharma/Xporcle-Extension/compare/v2.1.0...v2.2.0
 [v2.1.0]: https://github.com/ToranSharma/Xporcle-Extension/compare/v2.0.0...v2.1.0
 [v2.0.0]: https://github.com/ToranSharma/Xporcle-Extension/compare/v1.2.1...v2.0.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Changelog
   - Button for hosts to add the quiz they are on to the queue.
   - Draggable (for hosts) list of quizzes in the queue.
   - Remove button for hosts to remove quizzes from the queue.
+  - Go to quiz button for hosts to visit the page of quizzes in the queue.
 
 [v2.2.0] - 2021-08-16
 ---------------------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Changelog
 - Quiz Queue
   - Button for hosts to add the quiz they are on to the queue.
   - Draggable (for hosts) list of quizzes in the queue.
+  - Remove button for hosts to remove quizzes from the queue.
 
 [v2.2.0] - 2021-08-16
 ---------------------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ Changelog
   - Draggable (for hosts) list of quizzes in the queue.
   - Remove button for hosts to remove quizzes from the queue.
   - Go to quiz button for hosts to visit the page of quizzes in the queue.
+  - Controls for hosts to toggle and customise interval for auto changing to
+    next quiz.
 
 [v2.2.0] - 2021-08-16
 ---------------------

--- a/background.js
+++ b/background.js
@@ -244,7 +244,8 @@ function forwardMessage(event)
 	{
 		host = true;
 		urls = message["urls"];
-		poll_data = message["poll_data"] ?? {}
+		poll_data = message["poll_data"] ?? {};
+		queue = message["queue"];
 	}
 	else if (
 		messageType === "users_update"

--- a/background.js
+++ b/background.js
@@ -42,6 +42,7 @@ let voteData = {};
 let voted = false;
 let saveName = null;
 let queue = [];
+let queueInterval;
 
 chrome.runtime.onConnect.addListener(
 	(port) =>
@@ -72,7 +73,8 @@ chrome.runtime.onConnect.addListener(
 									vote_data: voteData,
 									saveName: saveName,
 									voted: voted,
-									queue: queue
+									queue: queue,
+									queue_interval: queueInterval
 								}
 							);
 							ws.send(JSON.stringify({type: "url_update", url: message["url"]}))
@@ -215,6 +217,7 @@ function forwardMessage(event)
 		{
 			hosts = message["hosts"];
 			queue = message["queue"];
+			queueInterval = message["queue_interval"];
 		}
 		else
 		{
@@ -246,6 +249,7 @@ function forwardMessage(event)
 		urls = message["urls"];
 		poll_data = message["poll_data"] ?? {};
 		queue = message["queue"];
+		queueInterval = message["queue_interval"];
 	}
 	else if (
 		messageType === "users_update"
@@ -326,6 +330,7 @@ function forwardMessage(event)
 	else if (messageType === "queue_update")
 	{
 		queue = message["queue"];
+		queueInterval = message["queue_interval"];
 	}
 
 	if (messagePort !== null)
@@ -349,4 +354,5 @@ function reset()
 	saveName = null;
 	voted = false;
 	queue = [];
+	queueInterval = null;
 }

--- a/background.js
+++ b/background.js
@@ -214,6 +214,7 @@ function forwardMessage(event)
 		if (message["success"])
 		{
 			hosts = message["hosts"];
+			queue = message["queue"];
 		}
 		else
 		{

--- a/background.js
+++ b/background.js
@@ -41,6 +41,7 @@ let pollData = {};
 let voteData = {};
 let voted = false;
 let saveName = null;
+let queue = [];
 
 chrome.runtime.onConnect.addListener(
 	(port) =>
@@ -70,7 +71,8 @@ chrome.runtime.onConnect.addListener(
 									poll_data: pollData,
 									vote_data: voteData,
 									saveName: saveName,
-									voted: voted
+									voted: voted,
+									queue: queue
 								}
 							);
 							ws.send(JSON.stringify({type: "url_update", url: message["url"]}))
@@ -319,6 +321,10 @@ function forwardMessage(event)
 	{
 		voteData = message["vote_data"];
 	}
+	else if (messageType === "queue_update")
+	{
+		queue = message["queue"];
+	}
 
 	if (messagePort !== null)
 	{
@@ -340,4 +346,5 @@ function reset()
 	voteData = {};
 	saveName = null;
 	voted = false;
+	queue = [];
 }

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
 	"name"				:	"Xporcle",
 	"description"		:	"Adds real-time multiplayer abilities to Sporcle.com",
-	"version"			:	"2.2.0",
+	"version"			:	"2.3.0",
 	"manifest_version"	:	2,
 	
 	"icons"				: 	{

--- a/options.html
+++ b/options.html
@@ -24,6 +24,14 @@
 			<input class="option" id="blurRoomCode" type="checkbox" />
 			<label for="blurRoomCode">Blur Room Code</label>
 		</li>
+		<li class="labelFirst containsTime">
+			<label for="defaultPollDuration containsTime">Default Poll Duration</label>
+			<input class="option" id="defaultPollDuration" type="number" value="30" min="10" max="60" />
+		</li>
+		<li class="labelFirst containsTime">
+			<label for="defaultQuizQueueInterval">Default Quiz Queue Interval</label>
+			<input class="option" id="defaultQuizQueueInterval" type="number" value="60" min="10" max="300" />
+		</li>
 	</ul>
 	<button id="enableAll">Enable all</button>
 	<button id="disableAll">Disable all</button>

--- a/options.html
+++ b/options.html
@@ -6,7 +6,7 @@
 	<link href="stylesheets/options.css" rel="stylesheet" />
 </head>
 <body>
-	<h1>Xporcle <span id="version">v2.2.0</span></h1>
+	<h1>Xporcle <span id="version">v2.3.0</span></h1>
 	<h2>Enable or Disable Features Here</h2>
 	<ul id="optionTree">
 		<li>

--- a/options.js
+++ b/options.js
@@ -101,6 +101,7 @@ function getOptions(firstLoad=false)
 					document.getElementById(option).checked = options[option];
 					break;
 				case "string":
+				case "number":
 					document.getElementById(option).value = options[option];
 					break;
 			}
@@ -119,6 +120,10 @@ function saveOptions()
 		if (element.type === "checkbox")
 		{
 			options[element.id] = element.checked;
+		}
+		else if (element.type === "number")
+		{
+			options[element.id] = Number(element.value);
 		}
 		else
 		{

--- a/stylesheets/interface.css
+++ b/stylesheets/interface.css
@@ -52,6 +52,13 @@
 		margin: 0 auto;
 
 	}
+#interfaceBox #changeQuizCountdown
+{
+	display: flex;
+	flex-direction: row;
+	justify-content: space-evenly;
+	flex-wrap: wrap;
+}
 
 #leaderboard,
 #liveScores

--- a/stylesheets/interface.css
+++ b/stylesheets/interface.css
@@ -366,15 +366,43 @@
 	text-align: center;
 }
 
-li[draggable="true"]
+
+#quizQueueBox li[draggable="true"]
 {
 	cursor: move;
+	position: relative;
+	padding-right: 2rem;
 }
-.moving
+#quizQueueBox li.moving
 {
 	color: transparent;	
 }
-li.moving::marker
+#quizQueueBox li.moving::marker
 {
 	color: black;
 }
+	#quizQueueBox li .closeButton
+	{
+		display: none;
+		visibility: hidden;
+		top: 0;
+	}
+	#quizQueueBox li:hover .closeButton
+	{
+		display: unset;
+		visibility: visible;
+	}
+	#quizQueueBox li:active .closeButton,
+	#quizQueueBox li.moving .closeButton,
+	#quizQueueBox li.moving:hover .closeButton,
+	#quizQueueBox li.moving ~ li .closeButton
+	{
+		display: none;
+		visibility: hidden;
+	}
+	#quizQueueBox li .closeButton:hover
+	{
+		display: unset;
+		visibility: visible;
+	}
+

--- a/stylesheets/interface.css
+++ b/stylesheets/interface.css
@@ -371,6 +371,7 @@
 {
 	display: grid;
 	grid-auto-rows: 1fr;
+	margin: 0;
 }
 	#quizQueueBox li[draggable="true"]
 	{

--- a/stylesheets/interface.css
+++ b/stylesheets/interface.css
@@ -38,6 +38,10 @@
 		margin: 0;
 	}
 
+#interfaceBox .toggle
+{
+	top: 0.5rem;
+}
 #interfaceBox form
 {
 	display: flex;
@@ -335,7 +339,7 @@
 	margin: 0;
 	border: 0;
 	position: absolute;
-	right: 2rem;
+	right: 1rem;
 	top: 1rem;
 	color: grey;
 	cursor: pointer;
@@ -344,6 +348,10 @@
 	text-align:center;
 	transform: rotate(0deg);
 	transition: transform 0.5s;
+}
+.closeButton ~ .toggle
+{
+	right: 2rem;
 }
 .toggle::after
 {

--- a/stylesheets/interface.css
+++ b/stylesheets/interface.css
@@ -15,20 +15,6 @@
 		max-width: 400px;
 		overflow: auto;
 	}
-	#interfaceContainer form
-	{
-		display: flex;
-		flex-direction: column;
-	}
-		#interfaceContainer form input,
-		#interfaceContainer form button,
-		#interfaceContainer form select
-		{
-			width: min(100%, 10em);
-			box-sizing: border-box;
-			margin: 0 auto;
-
-		}
 
 .interfaceSection
 {
@@ -52,6 +38,20 @@
 		margin: 0;
 	}
 
+#interfaceBox form
+{
+	display: flex;
+	flex-direction: column;
+}
+	#interfaceBox form input,
+	#interfaceBox form button,
+	#interfaceBox form select
+	{
+		width: min(100%, 10em);
+		box-sizing: border-box;
+		margin: 0 auto;
+
+	}
 
 #leaderboard,
 #liveScores
@@ -432,3 +432,16 @@
 			display: unset;
 			visibility: visible;
 		}
+#quizQueueBox form
+{
+	display: block;
+}
+	#quizQueueBox form input
+	{
+		display: inline;
+		vertical-align: baseline;
+	}
+	#quizQueueBox form input[type="number"]
+	{
+		width: 3.5em;
+	}

--- a/stylesheets/interface.css
+++ b/stylesheets/interface.css
@@ -366,6 +366,20 @@
 	text-align: center;
 }
 
+.goTo
+{		
+	appearance: none;
+	border: none;
+	padding: 0;
+	position: absolute;
+	top: 0;
+	right: 2rem;
+	width: 1rem;
+	height: 1rem;
+	background: url(data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAxNiAxNiIgd2lkdGg9IjE2IiBoZWlnaHQ9IjE2Ij48cGF0aCBkPSJNOSAyTDkgMyAxMi4zIDMgNiA5LjMgNi43IDEwIDEzIDMuNyAxMyA3IDE0IDcgMTQgMlpNNCA0QzIuOSA0IDIgNC45IDIgNkwyIDEyQzIgMTMuMSAyLjkgMTQgNCAxNEwxMCAxNEMxMS4xIDE0IDEyIDEzLjEgMTIgMTJMMTIgNyAxMSA4IDExIDEyQzExIDEyLjYgMTAuNiAxMyAxMCAxM0w0IDEzQzMuNCAxMyAzIDEyLjYgMyAxMkwzIDZDMyA1LjQgMy40IDUgNCA1TDggNSA5IDRaIi8+PC9zdmc+) no-repeat;
+	background-size: contain;
+	cursor: pointer;
+}
 
 #quizQueueBox ol
 {
@@ -377,7 +391,7 @@
 	{
 		cursor: move;
 		position: relative;
-		padding-right: 2rem;
+		padding-right: 3rem;
 	}
 	#quizQueueBox li.moving
 	{
@@ -387,13 +401,15 @@
 	{
 		color: black;
 	}
-		#quizQueueBox li .closeButton
+		#quizQueueBox li .closeButton,
+		#quizQueueBox li .goTo
 		{
 			display: none;
 			visibility: hidden;
 			top: 0;
 		}
-		#quizQueueBox li:hover .closeButton
+		#quizQueueBox li:hover .closeButton,
+		#quizQueueBox li:hover .goTo
 		{
 			display: unset;
 			visibility: visible;
@@ -401,14 +417,18 @@
 		#quizQueueBox li:active .closeButton,
 		#quizQueueBox li.moving .closeButton,
 		#quizQueueBox li.moving:hover .closeButton,
-		#quizQueueBox li.moving ~ li .closeButton
+		#quizQueueBox li.moving ~ li .closeButton,
+		#quizQueueBox li:active .goTo,
+		#quizQueueBox li.moving .goTo,
+		#quizQueueBox li.moving:hover .goTo,
+		#quizQueueBox li.moving ~ li .goTo
 		{
 			display: none;
 			visibility: hidden;
 		}
-		#quizQueueBox li .closeButton:hover
+		#quizQueueBox li .closeButton:hover,
+		#quizQueueBox li .goTo:hover
 		{
 			display: unset;
 			visibility: visible;
 		}
-

--- a/stylesheets/interface.css
+++ b/stylesheets/interface.css
@@ -366,3 +366,15 @@
 	text-align: center;
 }
 
+li[draggable="true"]
+{
+	cursor: move;
+}
+.moving
+{
+	color: transparent;	
+}
+li.moving::marker
+{
+	color: black;
+}

--- a/stylesheets/interface.css
+++ b/stylesheets/interface.css
@@ -349,8 +349,8 @@
 }
 .toggle:checked ~ *
 {
-	display: none;
-	visibility: hidden;
+	display: none !important;
+	visibility: hidden !important;
 }
 
 .closeButton::after,
@@ -367,42 +367,47 @@
 }
 
 
-#quizQueueBox li[draggable="true"]
+#quizQueueBox ol
 {
-	cursor: move;
-	position: relative;
-	padding-right: 2rem;
+	display: grid;
+	grid-auto-rows: 1fr;
 }
-#quizQueueBox li.moving
-{
-	color: transparent;	
-}
-#quizQueueBox li.moving::marker
-{
-	color: black;
-}
-	#quizQueueBox li .closeButton
+	#quizQueueBox li[draggable="true"]
 	{
-		display: none;
-		visibility: hidden;
-		top: 0;
+		cursor: move;
+		position: relative;
+		padding-right: 2rem;
 	}
-	#quizQueueBox li:hover .closeButton
+	#quizQueueBox li.moving
 	{
-		display: unset;
-		visibility: visible;
+		color: transparent;
 	}
-	#quizQueueBox li:active .closeButton,
-	#quizQueueBox li.moving .closeButton,
-	#quizQueueBox li.moving:hover .closeButton,
-	#quizQueueBox li.moving ~ li .closeButton
+	#quizQueueBox li.moving::marker
 	{
-		display: none;
-		visibility: hidden;
+		color: black;
 	}
-	#quizQueueBox li .closeButton:hover
-	{
-		display: unset;
-		visibility: visible;
-	}
+		#quizQueueBox li .closeButton
+		{
+			display: none;
+			visibility: hidden;
+			top: 0;
+		}
+		#quizQueueBox li:hover .closeButton
+		{
+			display: unset;
+			visibility: visible;
+		}
+		#quizQueueBox li:active .closeButton,
+		#quizQueueBox li.moving .closeButton,
+		#quizQueueBox li.moving:hover .closeButton,
+		#quizQueueBox li.moving ~ li .closeButton
+		{
+			display: none;
+			visibility: hidden;
+		}
+		#quizQueueBox li .closeButton:hover
+		{
+			display: unset;
+			visibility: visible;
+		}
 

--- a/stylesheets/options.css
+++ b/stylesheets/options.css
@@ -78,17 +78,21 @@ ul
 {
 	color: grey;
 }
-#optionTree .labelFirst
+#optionTree li.labelFirst
+{
+	grid-template-columns: max-content 4em;
+}
+#optionTree ul li.labelFirst
 {
 	grid-template-columns: 3em max-content 3em;
 }
-	#optionTree .labelFirst > label
-	{
-		padding-left: 0;
-		padding-right: 0.5em;
-		z-index: 3;
-		background-color: white;
-	}
+#optionTree .labelFirst > label
+{
+	padding-left: 0;
+	padding-right: 0.5em;
+	z-index: 3;
+	background-color: white;
+}
 
 #optionTree .labelFirst.containsTextInput
 {
@@ -117,6 +121,17 @@ ul
 	align-self: center;
 	height: 1.5em;
 	line-height: 1.5em;
+}
+
+#optionTree .containsTime::after
+{
+	content:"s";
+	height: 1.5em;
+	line-height: 1.5em;
+}
+#optionTree > li.labelFirst.containsTime
+{
+	grid-template-columns: max-content 4em auto;
 }
 
 button

--- a/xporcle.js
+++ b/xporcle.js
@@ -550,8 +550,48 @@ function processMessage(message)
 		case "queue_update":
 			updateQuizQueue(message["queue"], message["queue_interval"]);
 			break;
+		case "start_change_quiz_countdown":
+			{
+				const endTime = (new Date()).getTime() + message["countdown_length"]*1000;
+				const timeLeft = () => (Math.max(0, endTime - (new Date()).getTime())/1000).toFixed(1);
+				const countdown = document.createElement("div");
+				countdown.id = "changeQuizCountdown";
+				countdown.append(document.createElement("span"));
+				countdown.firstChild.textContent = `Changing to next quiz in ${timeLeft()}s`;
+				setInterval(
+					() =>
+					{
+						if (countdown.firstChild.textContent !== "Change quiz countdown cancelled")
+						{
+							countdown.firstChild.textContent = `Changing to next quiz in ${timeLeft()}s`;
+						}
+					}
+					, 100
+				);
+				if (host)
+				{
+					const cancelButton = document.createElement("button");
+					cancelButton.textContent = "Cancel Countdown";
+					cancelButton.addEventListener("click",
+						(event) =>
+						{
+							port.postMessage({type: "change_queue_interval", queue_interval: null});
+						}
+					);
+					countdown.append(cancelButton);
+				}
+				document.querySelector("#interfaceBox")?.insertBefore(countdown, document.querySelector("#leaderboard").nextElementSibling);
+				break;
+			}
+		case "cancel_change_quiz_countdown":
+			{
+				const countdownMessage = document.querySelector("#changeQuizCountdown span");
+				countdownMessage.textContent = "Change quiz countdown cancelled";
+				document.querySelector("#changeQuizCountdown button")?.remove();
+				setTimeout(() => countdownMessage.parentNode.remove(), 2000);
+				break;
+			}
 	}
-
 }
 
 function updateHostsInLeaderboard()

--- a/xporcle.js
+++ b/xporcle.js
@@ -2421,10 +2421,15 @@ function addQuizQueueBox(queue = [])
 function updateQuizQueue(queue)
 {
 	let quizQueueBox = document.querySelector("#quizQueueBox");
+	if (queue.length === 0)
+	{
+		return quizQueueBox?.remove();
+	}
 	if (quizQueueBox === null)
 	{
 		return addQuizQueueBox(queue);
 	}
+
 
 	const queueList = quizQueueBox.querySelector("ol");
 	Array.from(queueList.querySelectorAll("li"))

--- a/xporcle.js
+++ b/xporcle.js
@@ -858,6 +858,8 @@ function onRoomConnect(existingScores, existingPollData, currentVoteData, queue,
 	roomCodeHeader.lastChild.textContent = roomCode;
 	interfaceBox.insertBefore(roomCodeHeader, interfaceBox.firstElementChild);
 
+	interfaceBox.insertBefore(collapseToggle(),roomCodeHeader.nextElementSibling);
+
 	// If the user is a host and is on a quiz,
 	// add a button to send the quiz to the rest of the room
 	if (host && onQuizPage)
@@ -1004,7 +1006,7 @@ function addChangeQuizButton()
 	);
 
 	// The button goes just after the room code header
-	interfaceBox.insertBefore(changeQuizButton, interfaceBox.querySelector(`#roomCodeHeader`).nextElementSibling);
+	interfaceBox.insertBefore(changeQuizButton, interfaceBox.querySelector(`.toggle`).nextElementSibling);
 }
 
 function currentQuizInfo()

--- a/xporcle.js
+++ b/xporcle.js
@@ -143,7 +143,8 @@ async function init()
 
 		const pollData =  Object.keys(statusResponse["poll_data"]).length !== 0 ? statusResponse["poll_data"] : undefined;
 		const voteData =  Object.keys(statusResponse["vote_data"]).length !== 0 ? statusResponse["vote_data"] : undefined;
-		onRoomConnect(statusResponse["scores"], pollData, voteData);
+		const queue =  Object.keys(statusResponse["queue"]).length !== 0 ? statusResponse["queue"] : undefined;
+		onRoomConnect(statusResponse["scores"], pollData, voteData, queue);
 	}
 	else
 	{
@@ -353,9 +354,7 @@ function resetInterface(errorElement, lastUsername, lastCode)
 	setQuizStartProvention(false);
 	document.querySelectorAll("#startCountdown").forEach(elm => elm.remove());
 
-	document.querySelector("#pollBox")?.remove();
-	document.querySelector("#voteInfoBox")?.remove();
-	document.querySelector("#ballotPopout")?.remove();
+	document.querySelectorAll(".interfaceSection:not(#interfaceBox)").forEach(section => section.remove());
 
 	init().then(
 		() =>
@@ -466,6 +465,16 @@ function processMessage(message)
 			updateLeaderboardUrls();
 			updateContextMenuHandling();
 			addSaveRoomButton();
+			if (onQuizPage)
+			{
+				interfaceBox.append(addQuizToQueueButton());
+			}
+			if (message["queue"] !== null)
+			{
+				document.querySelector("#quizQueueBox")?.remove();
+				addQuizQueueBox(message["queue"]);
+			}
+
 			if (message["poll_data"] !== null)
 			{
 				addCreatePollBox(message["poll_data"]);
@@ -527,6 +536,9 @@ function processMessage(message)
 			break;
 		case "vote_update":
 			updateVoteInfoBox(message["vote_data"]);
+			break;
+		case "queue_update":
+			updateQuizQueue(message["queue"]);
 			break;
 	}
 
@@ -639,7 +651,7 @@ async function joinRoom(event)
 		username: username,
 		code: roomCode,
 	};
-
+	let queue = undefined;
 	try
 	{
 		port.postMessage({type: "startConnection", initialMessage: message});
@@ -656,6 +668,7 @@ async function joinRoom(event)
 						{
 							hosts = message["hosts"];
 							port.postMessage({type: "url_update", url: window.location.pathname})
+							queue = message["queue"] ?? undefined;
 
 							// Set up message handing
 							port.onMessage.addListener(processMessage);
@@ -689,7 +702,7 @@ async function joinRoom(event)
 		return;
 	}
 
-	onRoomConnect();
+	onRoomConnect(undefined, undefined, undefined, queue);
 }
 
 async function loadRoom(event, form)
@@ -774,7 +787,7 @@ async function loadRoom(event, form)
 
 	onRoomConnect();
 }
-function onRoomConnect(existingScores, existingPollData, currentVoteData)
+function onRoomConnect(existingScores, existingPollData, currentVoteData, queue)
 {
 	// Set up message handing if not done already.
 	if (!port.onMessage.hasListener(processMessage))
@@ -833,6 +846,8 @@ function onRoomConnect(existingScores, existingPollData, currentVoteData)
 	if (host)
 	{
 		addSaveRoomButton();
+
+		// Poll
 		if (existingPollData)
 		{
 			addCreatePollBox(existingPollData);
@@ -840,6 +855,12 @@ function onRoomConnect(existingScores, existingPollData, currentVoteData)
 		else
 		{
 			addCreatePollButton();
+		}
+
+		// Add Quiz to Queue
+		if (onQuizPage)
+		{
+			interfaceBox.append(addQuizToQueueButton());
 		}
 	}
 
@@ -852,6 +873,13 @@ function onRoomConnect(existingScores, existingPollData, currentVoteData)
 			addBallotPopout(currentVoteData.poll);
 		}
 	}
+
+	// Quiz Queue
+	if (queue)
+	{
+		addQuizQueueBox(queue);
+	}
+
 
 	// If on a quiz page, observe for the start of the quiz
 	if (onQuizPage)
@@ -929,10 +957,18 @@ function addChangeQuizButton()
 	interfaceBox.insertBefore(changeQuizButton, interfaceBox.querySelector(`#roomCodeHeader`).nextElementSibling);
 }
 
-function addSuggestionQuizButton()
+function currentQuizInfo()
 {
+	const url = window.location.href;
 	const shortTitle = document.querySelector(`title`).textContent;
 	const longTitle = document.querySelector("#gameMeta>h2").textContent;
+
+	return {url: url, short_title: shortTitle, long_title: longTitle};
+}
+
+function addSuggestionQuizButton()
+{
+	const quizInfo = currentQuizInfo();
 
 	const suggestQuizButton = document.createElement("button");
 	suggestQuizButton.id = "suggestQuizButton";
@@ -943,9 +979,9 @@ function addSuggestionQuizButton()
 			port.postMessage(
 				{
 					type: "suggest_quiz",
-					url: window.location.href,
-					short_title: shortTitle,
-					long_title: longTitle
+					url: quizInfo.url,
+					short_title: quizInfo.short_title,
+					long_title: quizInfo.long_title
 				}
 			);
 		}
@@ -989,12 +1025,7 @@ function addCreatePollBox(pollData)
 	if (onQuizPage)
 	{
 		// Get info about quiz from page
-		const currentQuiz =
-		{
-			url: window.location.href,
-			short_title: document.querySelector(`title`).textContent,
-			long_title: document.querySelector("#gameMeta>h2").textContent
-		};
+		const quizInfo = currentQuizInfo();
 
 		const addCurrentQuizToPollButton = document.createElement("button");
 		addCurrentQuizToPollButton.textContent = "Add Quiz to Poll";
@@ -1007,7 +1038,7 @@ function addCreatePollBox(pollData)
 					pollData.entries.push(currentQuiz);
 					const newEntryListItem = document.createElement("li");
 
-					newEntryListItem.textContent = currentQuiz.short_title;
+					newEntryListItem.textContent = quizInfo.short_title;
 
 					removeEntryButton = document.createElement("div");
 					removeEntryButton.textContent = "×";
@@ -1015,7 +1046,7 @@ function addCreatePollBox(pollData)
 						(event) =>
 						{
 							newEntryListItem.remove();
-							pollData.entries = pollData.entries.filter(existingEntry => existingEntry.url !== currentQuiz.url);
+							pollData.entries = pollData.entries.filter(existingEntry => existingEntry.url !== quizInfo.url);
 							port.postMessage({type:"poll_data_update", poll_data: pollData});
 						}
 					);
@@ -2344,4 +2375,150 @@ function collapseToggle()
 	toggle.classList.add("toggle");
 
 	return toggle;
+}
+
+function addQuizToQueueButton()
+{
+	const button = document.createElement("button");
+	button.textContent = "Add Quiz to Queue";
+	button.addEventListener("click",
+		(event) =>
+		{
+			const quizInfo = currentQuizInfo();
+			const existingQueuedQuizes = Array.from(document.querySelectorAll("#quizQueueBox ol li"));
+
+			if (!existingQueuedQuizes.find(queuedQuiz => queuedQuiz.short_title === quizInfo.short_title))
+			{
+				port.postMessage({type: "add_to_queue", quiz: quizInfo});
+			}
+		}
+	);
+	return button;
+}
+
+function addQuizQueueBox(queue = [])
+{
+	const quizQueueBox = document.createElement("div");
+	quizQueueBox.classList.add("interfaceSection");
+	quizQueueBox.id = "quizQueueBox";
+
+	quizQueueBox.append(closeButton(quizQueueBox));
+
+	const header = document.createElement("h2");
+	header.textContent = "Quiz Queue";
+	quizQueueBox.append(header);
+
+	quizQueueBox.append(collapseToggle());
+
+	const queueList = document.createElement("ol");
+	quizQueueBox.append(queueList);
+
+	sectionContainer.append(quizQueueBox);
+
+	updateQuizQueue(queue);
+}
+
+function updateQuizQueue(queue)
+{
+	let quizQueueBox = document.querySelector("#quizQueueBox");
+	if (quizQueueBox === null)
+	{
+		return addQuizQueueBox(queue);
+	}
+
+	const queueList = quizQueueBox.querySelector("ol");
+	Array.from(queueList.querySelectorAll("li"))
+		.filter(li => queue.some(queuedQuiz => queuedQuiz.short_title === li.textContent))
+		.forEach(li => li.remove());
+
+	queue.forEach(
+		(queuedQuiz) =>
+		{
+			let li = Array.from(queueList.querySelectorAll("li")).find(li => li.textContent === queuedQuiz.short_title);
+			if (li === undefined)
+			{
+				li = document.createElement("li");
+				li.textContent = queuedQuiz.short_title;
+				if (host)
+				{
+					li.setAttribute("draggable", "true");
+					li.addEventListener("dragstart",
+						(event) =>
+						{
+							const quizInfoString = JSON.stringify(queuedQuiz);
+							event.dataTransfer.setData("text/quizinfo", quizInfoString);
+							const dragImage = document.createElement("div");
+							dragImage.id = "tempDragImage";
+							dragImage.style =
+							`
+								position: absolute;
+								top: -2000vh;
+								left: -2000vw;
+								width: ${event.target.clientWidth}px;
+							`;
+							dragImage.textContent = event.target.textContent;
+							document.body.append(dragImage);
+
+							event.dataTransfer.setDragImage(dragImage, 30, dragImage.clientHeight/2);
+							event.dataTransfer.effectAllowed = "move";
+							event.target.classList.add("moving");
+						}
+					);
+					li.addEventListener("dragend",
+						(event) =>
+						{
+							event.target.classList.remove("moving");
+							event.target.style = "";
+							document.querySelector("#tempDragImage")?.remove();
+						}
+					);
+					li.addEventListener("dragenter",
+						(event) =>
+						{
+							if (event.dataTransfer.types.includes("text/quizinfo"))
+							{
+								event.preventDefault();
+								event.dataTransfer.dropEffect = "move";
+								const beingDragged = queueList.querySelector(".moving");
+
+								const indexOffset =
+									Array.from(queueList.childNodes).indexOf(event.target)
+									- Array.from(queueList.childNodes).indexOf(beingDragged);
+								if (indexOffset > 0)
+								{
+									// Element being dragged is above the target.
+									// So we want to move the dragged element to just below/after it.
+									queueList.insertBefore(beingDragged, event.target.nextElementSibling);
+								}
+								else
+								{
+									// Element being dragged is below the target
+									// So we want to move the dragged element to just above/before it.
+									queueList.insertBefore(beingDragged, event.target);
+								}
+							}
+						}
+					);
+					li.addEventListener("dragover",
+						(event) =>
+						{
+							if (event.dataTransfer.types.includes("text/quizinfo"))
+							{
+								event.preventDefault();
+								event.dataTransfer.dropEffect = "move";
+							}
+						}
+					);
+					li.addEventListener("drop",
+						(event) =>
+						{
+							const newIndex = Array.from(queueList.children).indexOf(document.querySelector(".moving"));
+							port.postMessage({type: "reorder_queue", quiz: queuedQuiz, index: newIndex});
+						}
+					);
+				}
+			}
+			queueList.append(li);
+		}
+	);
 }

--- a/xporcle.js
+++ b/xporcle.js
@@ -2446,6 +2446,11 @@ function updateQuizQueue(queue)
 				li.textContent = queuedQuiz.short_title;
 				if (host)
 				{
+					// Add go to button
+					const goToButton = document.createElement("button");
+					goToButton.classList.add("goTo");
+					goToButton.addEventListener("click", (event) => {window.location = queuedQuiz.url});
+					li.append(goToButton);
 					// Add Remove Button
 					li.append(
 						closeButton(li,
@@ -2471,7 +2476,7 @@ function updateQuizQueue(queue)
 								left: -2000vw;
 								width: calc(${event.target.clientWidth}px - ${window.getComputedStyle(event.target).paddingRight});
 							`;
-							dragImage.textContent = event.target.textContent;
+							dragImage.textContent = queuedQuiz.short_title;
 							document.body.append(dragImage);
 
 							event.dataTransfer.setDragImage(dragImage, 30, dragImage.clientHeight/2);

--- a/xporcle.js
+++ b/xporcle.js
@@ -262,11 +262,11 @@ function applyOptions()
 	// Blur Room Code
 	if (options.blurRoomCode)
 	{
-		document.body.classList.add(".blurRoomCode");
+		document.body.classList.add("blurRoomCode");
 	}
 	else
 	{
-		document.body.classList.remove(".blurRoomCode");
+		document.body.classList.remove("blurRoomCode");
 	}
 }
 

--- a/xporcle.js
+++ b/xporcle.js
@@ -205,7 +205,9 @@ function retrieveOptions()
 				{
 					useDefaultUsername: false,
 					defaultUsername: "",
-					blurRoomCode: false
+					blurRoomCode: false,
+					defaultPollDuration: 30,
+					defaultQuizQueueInterval: 60
 				};
 
 			if (Object.entries(data).length === 0)
@@ -1050,7 +1052,7 @@ function addCreatePollButton()
 	createPollButton.addEventListener("click",
 		(event) =>
 		{
-			const pollData = {duration: 30, entries: []};
+			const pollData = {duration: options.defaultPollDuration, entries: []};
 			addCreatePollBox(pollData);
 			port.postMessage({type: "poll_create", poll_data: pollData});
 			createPollButton.remove();
@@ -2478,7 +2480,7 @@ function addQuizQueueBox(queue = [], queueInterval)
 		intervalInput.type = "number";
 		intervalInput.min = 10;
 		intervalInput.max = 60*5;
-		intervalInput.value = queueInterval ?? "60";
+		intervalInput.value = queueInterval ?? options.defaultQuizQueueInterval;
 		intervalInput.disabled = !autoChangeToggleInput.checked;
 		[autoChangeToggleInput, intervalInput].forEach(
 			(input) =>

--- a/xporcle.js
+++ b/xporcle.js
@@ -2428,7 +2428,7 @@ function updateQuizQueue(queue)
 
 	const queueList = quizQueueBox.querySelector("ol");
 	Array.from(queueList.querySelectorAll("li"))
-		.filter(li => queue.some(queuedQuiz => queuedQuiz.short_title === li.textContent))
+		.filter(li => !queue.some(queuedQuiz => queuedQuiz.short_title === li.textContent))
 		.forEach(li => li.remove());
 
 	queue.forEach(
@@ -2441,6 +2441,16 @@ function updateQuizQueue(queue)
 				li.textContent = queuedQuiz.short_title;
 				if (host)
 				{
+					// Add Remove Button
+					li.append(
+						closeButton(li,
+							(event) =>
+							{
+								port.postMessage({type: "remove_from_queue", quiz: queuedQuiz});
+							}
+						)
+					);
+					// Make list draggable to reorder queue.
 					li.setAttribute("draggable", "true");
 					li.addEventListener("dragstart",
 						(event) =>
@@ -2454,7 +2464,7 @@ function updateQuizQueue(queue)
 								position: absolute;
 								top: -2000vh;
 								left: -2000vw;
-								width: ${event.target.clientWidth}px;
+								width: calc(${event.target.clientWidth}px - ${window.getComputedStyle(event.target).paddingRight});
 							`;
 							dragImage.textContent = event.target.textContent;
 							document.body.append(dragImage);

--- a/xporcle.js
+++ b/xporcle.js
@@ -442,7 +442,16 @@ function processMessage(message)
 				updateLeaderboardUrls();
 
 				suggestions = [];
-				document.querySelectorAll(`#changeQuizButton, #suggestionsHeader, #suggestionsList, #saveButton, #createPollButton`).forEach(element => element.remove());
+				document.querySelectorAll(
+					`
+						#changeQuizButton,
+						#suggestionsHeader, #suggestionsList,
+						#saveButton,
+						#createPollButton, #pollBox,
+						#addQuizToQueueButton, #quizQueueBox form, #quizQueueBox ol button
+					`
+				).forEach(element => element.remove());
+				document.querySelectorAll(`#quizQueueBox ol li`).forEach(li => li.removeAttribute("draggable"));
 
 				// Add non host features
 				if (onQuizPage)


### PR DESCRIPTION
### Added
- Quiz Queue
  - Button for hosts to add the quiz they are on to the queue.
  - Draggable (for hosts) list of quizzes in the queue.
  - Remove button for hosts to remove quizzes from the queue.
  - Go to quiz button for hosts to visit the page of quizzes in the queue.
  - Controls for hosts to toggle and customise interval for auto changing to
    next quiz.
	- Option to set default interval for auto changing.
    - Countdown under leaderboard displaying time left until change to next
    quiz.
    - Button to cancel the countdown for hosts.
- Option to set default duration for next quiz polls.